### PR TITLE
Correção/inclusão dos blogs da EximiaCo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Esta lista será constantemente atualizada, e você também pode contribuir.
 * https://dirceuresende.com
 * https://docs.microsoft.com/pt-br/dotnet/core
 * https://docs.microsoft.com/pt-br/learn
-* https://eximiaco.tech/pt/blog
+* https://arquiteturadesoftware.online/
+* https://arquiteturadesoftware.online/podcast/
 * https://fullcycle.com.br
 * https://gago.io/dotnet
 * https://gbbigardi.medium.com


### PR DESCRIPTION
- Substituição do antigo blog de tecnologia da Eximia (https://eximiaco.tech/pt/blog). Pelo novo blog (https://arquiteturadesoftware.online/);
- Inclusão do podcast Arquitetura de Software da EximiaCo (https://arquiteturadesoftware.online/podcast/).